### PR TITLE
feat(indexer) update psql indexer to have configurable table names

### DIFF
--- a/.changelog/unreleased/features/3593-psql-configurable-tables.md
+++ b/.changelog/unreleased/features/3593-psql-configurable-tables.md
@@ -1,0 +1,2 @@
+-  `[indexer]` Introduces configurable table names for the PSQL indexer.
+  ([\#3593](https://github.com/cometbft/cometbft/issues/3593))

--- a/config/config.go
+++ b/config/config.go
@@ -1405,6 +1405,15 @@ type TxIndexConfig struct {
 	// The PostgreSQL connection configuration, the connection format:
 	// postgresql://<user>:<password>@<host>:<port>/<db>?<opts>
 	PsqlConn string `mapstructure:"psql-conn"`
+
+	// The PostgreSQL table that stores indexed blocks.
+	TableBlocks string `mapstructure:"table_blocks"`
+	// The PostgreSQL table that stores indexed transaction results.
+	TableTxResults string `mapstructure:"table_tx_results"`
+	// The PostgreSQL table that stores indexed events.
+	TableEvents string `mapstructure:"table_events"`
+	// The PostgreSQL table that stores indexed attributes.
+	TableAttributes string `mapstructure:"table_attributes"`
 }
 
 // DefaultTxIndexConfig returns a default configuration for the transaction indexer.

--- a/docs/guides/app-dev/indexing-transactions.md
+++ b/docs/guides/app-dev/indexing-transactions.md
@@ -151,10 +151,10 @@ Example:
 ```toml
 [tx-index]
 psql-conn = "your connection string"
-table_blocks = "comet_blocks"
-table_tx_results = "comet_tx_results"
-table_events = "comet_events"
-table_attributes = "comet_attributes"
+table_blocks = "cometbft_blocks"
+table_tx_results = "cometbft_tx_results"
+table_events = "cometbft_events"
+table_attributes = "cometbft_attributes"
 ```
 
 ## Default Indexes

--- a/docs/guides/app-dev/indexing-transactions.md
+++ b/docs/guides/app-dev/indexing-transactions.md
@@ -142,6 +142,21 @@ Example:
 psql ... -f state/indexer/sink/psql/schema.sql
 ```
 
+Table names are configurable should there be name collisions with existing databases. 
+The defaults are `blocks`, `tx_results`, `events`, and `attributes`. Should these be modified, 
+the `state/indexer/sink/psql/schema.sql` will also need to be adjusted to match so that the correct 
+schemas and table relations are created.
+
+Example:
+```toml
+[tx-index]
+psql-conn = "your connection string"
+table_blocks = "comet_blocks"
+table_tx_results = "comet_tx_results"
+table_events = "comet_events"
+table_attributes = "comet_attributes"
+```
+
 ## Default Indexes
 
 The CometBFT tx and block event indexer indexes a few select reserved events

--- a/state/indexer/block/indexer.go
+++ b/state/indexer/block/indexer.go
@@ -38,7 +38,26 @@ func IndexerFromConfig(cfg *config.Config, dbProvider config.DBProvider, chainID
 		if conn == "" {
 			return nil, nil, false, errors.New("the psql connection settings cannot be empty")
 		}
-		es, err := psql.NewEventSink(cfg.TxIndex.PsqlConn, chainID)
+		opts := []psql.EventSinkOption{}
+
+		txIndexCfg := cfg.TxIndex
+		if txIndexCfg.TableBlocks != "" {
+			opts = append(opts, psql.WithTableBlocks(txIndexCfg.TableBlocks))
+		}
+
+		if txIndexCfg.TableTxResults != "" {
+			opts = append(opts, psql.WithTableTxResults(txIndexCfg.TableTxResults))
+		}
+
+		if txIndexCfg.TableEvents != "" {
+			opts = append(opts, psql.WithTableEvents(txIndexCfg.TableEvents))
+		}
+
+		if txIndexCfg.TableAttributes != "" {
+			opts = append(opts, psql.WithTableAttributes(txIndexCfg.TableAttributes))
+		}
+
+		es, err := psql.NewEventSink(cfg.TxIndex.PsqlConn, chainID, opts...)
 		if err != nil {
 			return nil, nil, false, fmt.Errorf("creating psql indexer: %w", err)
 		}

--- a/state/indexer/sink/psql/psql.go
+++ b/state/indexer/sink/psql/psql.go
@@ -20,33 +20,82 @@ import (
 )
 
 const (
-	tableBlocks     = "blocks"
-	tableTxResults  = "tx_results"
-	tableEvents     = "events"
-	tableAttributes = "attributes"
-	driverName      = "postgres"
+	defaultTableBlocks     = "blocks"
+	defaultTableTxResults  = "tx_results"
+	defaultTableEvents     = "events"
+	defaultTableAttributes = "attributes"
+	driverName             = "postgres"
 )
 
 // EventSink is an indexer backend providing the tx/block index services.  This
 // implementation stores records in a PostgreSQL database using the schema
 // defined in state/indexer/sink/psql/schema.sql.
 type EventSink struct {
-	store   *sql.DB
-	chainID string
+	store           *sql.DB
+	chainID         string
+	tableBlocks     string
+	tableTxResults  string
+	tableEvents     string
+	tableAttributes string
 }
+
+type EventSinkOption func(*EventSink)
 
 // NewEventSink constructs an event sink associated with the PostgreSQL
 // database specified by connStr. Events written to the sink are attributed to
 // the specified chainID.
-func NewEventSink(connStr, chainID string) (*EventSink, error) {
-	db, err := sql.Open(driverName, connStr)
-	if err != nil {
-		return nil, err
+func NewEventSink(connStr, chainID string, opts ...EventSinkOption) (*EventSink, error) {
+	es := &EventSink{
+		chainID:         chainID,
+		tableBlocks:     defaultTableBlocks,
+		tableTxResults:  defaultTableTxResults,
+		tableEvents:     defaultTableEvents,
+		tableAttributes: defaultTableAttributes,
 	}
-	return &EventSink{
-		store:   db,
-		chainID: chainID,
-	}, nil
+
+	for _, opt := range opts {
+		opt(es)
+	}
+
+	if es.store == nil && connStr != "" {
+		db, err := sql.Open(driverName, connStr)
+		if err != nil {
+			return nil, err
+		}
+		es.store = db
+	}
+
+	return es, nil
+}
+
+func WithStore(store *sql.DB) EventSinkOption {
+	return func(es *EventSink) {
+		es.store = store
+	}
+}
+
+func WithTableBlocks(tableBlocks string) EventSinkOption {
+	return func(es *EventSink) {
+		es.tableBlocks = tableBlocks
+	}
+}
+
+func WithTableTxResults(tableTxResults string) EventSinkOption {
+	return func(es *EventSink) {
+		es.tableTxResults = tableTxResults
+	}
+}
+
+func WithTableEvents(tableEvents string) EventSinkOption {
+	return func(es *EventSink) {
+		es.tableEvents = tableEvents
+	}
+}
+
+func WithTableAttributes(tableAttributes string) EventSinkOption {
+	return func(es *EventSink) {
+		es.tableAttributes = tableAttributes
+	}
 }
 
 // DB returns the underlying Postgres connection used by the sink.
@@ -146,7 +195,7 @@ func (es *EventSink) IndexBlockEvents(h types.EventDataNewBlockEvents) error {
 	var blockID int64
 	//nolint:execinquery
 	err := es.store.QueryRow(`
-INSERT INTO `+tableBlocks+` (height, chain_id, created_at)
+INSERT INTO `+es.tableBlocks+` (height, chain_id, created_at)
   VALUES ($1, $2, $3)
   ON CONFLICT DO NOTHING
   RETURNING rowid;
@@ -161,10 +210,10 @@ INSERT INTO `+tableBlocks+` (height, chain_id, created_at)
 	events := append([]abci.Event{makeIndexedEvent(types.BlockHeightKey, strconv.FormatInt(h.Height, 10))}, h.Events...)
 	// Insert all the block events. Order is important here,
 	eventInserts, attrInserts := bulkInsertEvents(blockID, 0, events)
-	if err := runBulkInsert(es.store, tableEvents, eventInsertColumns, eventInserts); err != nil {
+	if err := runBulkInsert(es.store, es.tableEvents, eventInsertColumns, eventInserts); err != nil {
 		return fmt.Errorf("failed bulk insert of events: %w", err)
 	}
-	if err := runBulkInsert(es.store, tableAttributes, attrInsertColumns, attrInserts); err != nil {
+	if err := runBulkInsert(es.store, es.tableAttributes, attrInsertColumns, attrInserts); err != nil {
 		return fmt.Errorf("failed bulk insert of attributes: %w", err)
 	}
 	return nil
@@ -175,7 +224,7 @@ func (es *EventSink) getBlockIDs(heights []int64) ([]int64, error) {
 	var blockIDs pq.Int64Array
 	if err := es.store.QueryRow(`
 SELECT array_agg((
-	SELECT rowid FROM `+tableBlocks+` WHERE height = txr.height AND chain_id = $1
+	SELECT rowid FROM `+es.tableBlocks+` WHERE height = txr.height AND chain_id = $1
 )) FROM unnest($2::bigint[]) AS txr(height);`,
 		es.chainID, pq.Array(heights)).Scan(&blockIDs); err != nil {
 		return nil, fmt.Errorf("getting block ids for txs from sql: %w", err)
@@ -183,11 +232,11 @@ SELECT array_agg((
 	return blockIDs, nil
 }
 
-func prefetchTxrExistence(db *sql.DB, blockIDs []int64, indexes []uint32) ([]bool, error) {
+func prefetchTxrExistence(db *sql.DB, blockIDs []int64, indexes []uint32, txResultsTable string) ([]bool, error) {
 	var existence []bool
 	if err := db.QueryRow(`
 SELECT array_agg((
-	SELECT EXISTS(SELECT 1 FROM `+tableTxResults+` WHERE block_id = txr.block_id AND index = txr.index)
+	SELECT EXISTS(SELECT 1 FROM `+txResultsTable+` WHERE block_id = txr.block_id AND index = txr.index)
 )) FROM UNNEST($1::bigint[], $2::integer[]) as txr(block_id, index);`,
 		pq.Array(blockIDs), pq.Array(indexes)).Scan((*pq.BoolArray)(&existence)); err != nil {
 		return nil, fmt.Errorf("fetching already indexed txrs: %w", err)
@@ -209,7 +258,7 @@ func (es *EventSink) IndexTxEvents(txrs []*abci.TxResult) error {
 	if err != nil {
 		return fmt.Errorf("getting block ids for txs: %w", err)
 	}
-	alreadyIndexed, err := prefetchTxrExistence(es.store, blockIDs, indexes)
+	alreadyIndexed, err := prefetchTxrExistence(es.store, blockIDs, indexes, es.tableTxResults)
 	if err != nil {
 		return fmt.Errorf("failed to prefetch which txrs were already indexed: %w", err)
 	}
@@ -239,13 +288,13 @@ func (es *EventSink) IndexTxEvents(txrs []*abci.TxResult) error {
 		eventInserts = append(eventInserts, newEventInserts...)
 		attrInserts = append(attrInserts, newAttrInserts...)
 	}
-	if err := runBulkInsert(es.store, tableTxResults, txrInsertColumns, txrInserts); err != nil {
+	if err := runBulkInsert(es.store, es.tableTxResults, txrInsertColumns, txrInserts); err != nil {
 		return fmt.Errorf("bulk inserting txrs: %w", err)
 	}
-	if err := runBulkInsert(es.store, tableEvents, eventInsertColumns, eventInserts); err != nil {
+	if err := runBulkInsert(es.store, es.tableEvents, eventInsertColumns, eventInserts); err != nil {
 		return fmt.Errorf("bulk inserting events: %w", err)
 	}
-	if err := runBulkInsert(es.store, tableAttributes, attrInsertColumns, attrInserts); err != nil {
+	if err := runBulkInsert(es.store, es.tableAttributes, attrInsertColumns, attrInserts); err != nil {
 		return fmt.Errorf("bulk inserting attributes: %w", err)
 	}
 	return nil

--- a/state/indexer/sink/psql/psql_test.go
+++ b/state/indexer/sink/psql/psql_test.go
@@ -146,8 +146,8 @@ func TestIndexing(t *testing.T) {
 		require.Nil(t, err, "event sink creation")
 		require.NoError(t, indexer.IndexBlockEvents(newTestBlockEvents()))
 
-		verifyBlock(t, 1)
-		verifyBlock(t, 2)
+		verifyBlock(t, indexer, 1)
+		verifyBlock(t, indexer, 2)
 
 		verifyNotImplemented(t, "hasBlock", func() (bool, error) { return indexer.HasBlock(1) })
 		verifyNotImplemented(t, "hasBlock", func() (bool, error) { return indexer.HasBlock(2) })
@@ -157,7 +157,7 @@ func TestIndexing(t *testing.T) {
 			return v != nil, err
 		})
 
-		require.NoError(t, verifyTimeStamp(defaultTableBlocks))
+		require.NoError(t, verifyTimeStamp(indexer.tableBlocks))
 
 		// Attempting to reindex the same events should gracefully succeed.
 		require.NoError(t, indexer.IndexBlockEvents(newTestBlockEvents()))
@@ -182,11 +182,11 @@ func TestIndexing(t *testing.T) {
 		})
 		require.NoError(t, indexer.IndexTxEvents([]*abci.TxResult{txResult}))
 
-		txr, err := loadTxResult(types.Tx(txResult.Tx).Hash())
+		txr, err := loadTxResult(indexer, types.Tx(txResult.Tx).Hash())
 		require.NoError(t, err)
 		assert.Equal(t, txResult, txr)
 
-		require.NoError(t, verifyTimeStamp(defaultTableTxResults))
+		require.NoError(t, verifyTimeStamp(indexer.tableTxResults))
 		require.NoError(t, verifyTimeStamp(viewTxEvents))
 
 		verifyNotImplemented(t, "getTxByHash", func() (bool, error) {
@@ -317,11 +317,11 @@ func txResultWithEvents(events []abci.Event) *abci.TxResult {
 	}
 }
 
-func loadTxResult(hash []byte) (*abci.TxResult, error) {
+func loadTxResult(indexer *EventSink, hash []byte) (*abci.TxResult, error) {
 	hashString := fmt.Sprintf("%X", hash)
 	var resultData []byte
-	if err := testDB().QueryRow(`
-SELECT tx_result FROM `+defaultTableTxResults+` WHERE tx_hash = $1;
+	if err := indexer.store.QueryRow(`
+SELECT tx_result FROM `+indexer.tableTxResults+` WHERE tx_hash = $1;
 `, hashString).Scan(&resultData); err != nil {
 		return nil, fmt.Errorf("lookup transaction for hash %q failed: %v", hashString, err)
 	}
@@ -342,11 +342,11 @@ SELECT DISTINCT %[1]s.created_at
 `, tableName), time.Now().Add(-2*time.Second)).Err()
 }
 
-func verifyBlock(t *testing.T, height int64) {
+func verifyBlock(t *testing.T, indexer *EventSink, height int64) {
 	t.Helper()
 	// Check that the blocks table contains an entry for this height.
-	if err := testDB().QueryRow(`
-SELECT height FROM `+defaultTableBlocks+` WHERE height = $1;
+	if err := indexer.store.QueryRow(`
+SELECT height FROM `+indexer.tableBlocks+` WHERE height = $1;
 `, height).Err(); errors.Is(err, sql.ErrNoRows) {
 		t.Errorf("No block found for height=%d", height)
 	} else if err != nil {
@@ -354,7 +354,7 @@ SELECT height FROM `+defaultTableBlocks+` WHERE height = $1;
 	}
 
 	// Verify the presence of begin_block and end_block events.
-	if err := testDB().QueryRow(`
+	if err := indexer.store.QueryRow(`
 SELECT type, height, chain_id FROM `+viewBlockEvents+`
   WHERE height = $1 AND type = $2 AND chain_id = $3;
 `, height, eventTypeFinalizeBlock, chainID).Err(); errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
Closes #3565 

- Updates the psql indexer to accept table names.
- Introduces optional arguments to the `NewEventSink(...)` constructor as to retain backwards compatibility. This includes all four table names as well as a `*sql.DB` reference for test or other usage.
- The `NewEventSink(...)` is modified to add a passed in `*sql.DB` instance to the struct and if that is not set, then create a new database connection and set within the event sink.
- Renames the default table names constants with a prefix `default` to make clear where they're used.
- Stores configured table names within the `EventSink` struct instead of references the global default variables.
- Updates tests to use constructor to exercise that code path. Manually constructing the struct does not set the defaults within the struct.
- Adds four new options to the `.toml` config which get passed to the `NewEventSink` should any be set (not an empty string).

---

#### PR checklist

- [X] Tests written/updated
- [X] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [X] Updated relevant documentation (`docs/` or `spec/`) and code comments
- [X] Title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) spec
